### PR TITLE
handle malformed json in FitbitClient::Network::Request parse_response

### DIFF
--- a/lib/fitbit_client/network/request.rb
+++ b/lib/fitbit_client/network/request.rb
@@ -62,7 +62,11 @@ module FitbitClient
 
       def parse_response(response)
         return {} if response.nil? || response.body.nil? || response.body.empty?
-        JSON.parse response.body
+        begin
+          JSON.parse response.body
+        rescue JSON::ParserError => e
+          {}
+        end
       end
 
       def check_unrecoverable_token(parsed_response, error)

--- a/lib/fitbit_client/version.rb
+++ b/lib/fitbit_client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FitbitClient
-  VERSION = '0.1.4'
+  VERSION = '0.1.5'
 end


### PR DESCRIPTION
# F
this fixes `JSON::ParserError` error which occurs when `Fitbit` returns malformed json

# T
- [ ] local tests must pass:
```
$ bundle exec rake test
```

# D
deploy with no special instructions